### PR TITLE
Fix charter link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SIG-security covers security reporting and initiatives for the Open 3D Engine project. 
 
-The [charter]() defines the scope and responsibilities of this SIG.
+The [charter](governance/SIG%20Security%20Charter.md) defines the scope and responsibilities of this SIG.
 
 ## Meetings
 


### PR DESCRIPTION
Add missing link to official charter under /governance

### Testing

Updated link works at: https://github.com/allisaurus/sig-security/tree/charterlink 