### PR TITLE
Add checking Dependabot to triage guide

### DIFF
--- a/TRIAGE_GUIDE.md
+++ b/TRIAGE_GUIDE.md
@@ -14,6 +14,8 @@ Brief overview of process for maintainers:
 ## Triage Links
 * O3DE issues to triage for SIG: https://github.com/o3de/o3de/issues?q=is%3Aissue+is%3Aopen+label%3Aneeds-triage+label%3Asig%2Fsecurity
 * O3DE known security issues: https://github.com/o3de/o3de/issues?q=is%3Aissue+is%3Aopen+label%3Akind%2Fsecurity
+* Dependabot alerts (link only accessible to SIG-Security maintainers): https://github.com/o3de/o3de/security/dependabot
+    * Create issues for new alerts
 
 ## SIG Specific Guide
 * Ensure issues have the label `kind\security` set on them. SIG security uses this label to find issues assigned to other SIGs.

--- a/TRIAGE_GUIDE.md
+++ b/TRIAGE_GUIDE.md
@@ -14,8 +14,8 @@ Brief overview of process for maintainers:
 ## Triage Links
 * O3DE issues to triage for SIG: https://github.com/o3de/o3de/issues?q=is%3Aissue+is%3Aopen+label%3Aneeds-triage+label%3Asig%2Fsecurity
 * O3DE known security issues: https://github.com/o3de/o3de/issues?q=is%3Aissue+is%3Aopen+label%3Akind%2Fsecurity
-* Dependabot alerts (link only accessible to SIG-Security maintainers): https://github.com/o3de/o3de/security/dependabot
-    * Create issues for new alerts
+* Dependabot alerts to check (link only accessible to SIG-Security maintainers): https://github.com/o3de/o3de/security/dependabot
+    * For new alerts, create new GitHub issues against [O3DE](https://github.com/o3de/o3de) and tag with `kind\security` label for tracking.
 
 ## SIG Specific Guide
 * Ensure issues have the label `kind\security` set on them. SIG security uses this label to find issues assigned to other SIGs.


### PR DESCRIPTION
Per discussion at 5/25/2022 SIG meeting, adding note about checking for Dependabot alerts to triage guide.
